### PR TITLE
updated certs from letsencrypt-prod to letsencrypt-staging to avoid r…

### DIFF
--- a/kube/certs/certificate-external.yml
+++ b/kube/certs/certificate-external.yml
@@ -10,5 +10,5 @@ spec:
   - "*.branch.sas-notprod.homeoffice.gov.uk"  
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: letsencrypt-staging
   secretName: branch-tls-external

--- a/kube/certs/certificate-internal.yml
+++ b/kube/certs/certificate-internal.yml
@@ -10,5 +10,5 @@ spec:
   - "*.internal.branch.sas-notprod.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: letsencrypt-staging
   secretName: branch-tls-internal


### PR DESCRIPTION
…atelimts error

## What? 
Updated the branch-tls-external/internal certs from letsencrypt-prod to letsencrypt-staging 
## Why? 
This will avoid the deployment failure which comes as a result of rate limit failure
## How? 
letsencrypt-staging does not have rate limit. This will allow successful deployments without exceeding the rate limits which usually leads to failed deployments.
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [] I have written tests (if relevant)


