### PR TITLE
EVC-80 fix validation

### DIFF
--- a/apps/evisa/fields/index.js
+++ b/apps/evisa/fields/index.js
@@ -10,8 +10,8 @@
 const BRPValidator = { type: 'regex', arguments: /^r[a-z](\d|X)\d{6}$/i };
 
 // Unique Reference Number validator
-// URN number format: 1111-2222-3333-4444 with optional dash - or slash / group separators
-const URNValidator = { type: 'regex', arguments: /^\d{4}(?:[-\/]?)\d{4}(?:[-\/]?)\d{4}(?:[-\/]?)\d{4}$/ };
+// URN number format: 1111-2222-3333-4444 with dash - or slash / group separators
+const URNValidator = { type: 'regex', arguments: /^(\d{4}[-\/]){3}\d{4}$/ };
 
 // Passport number validator
 const PassportValidator = { type: 'regex', arguments: /^[a-z0-9]{9,10}$/i };

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -2,16 +2,18 @@ const { URNValidator } = require('../../apps/evisa/fields/index.js');
 
 describe('Custom Validators', () => {
   describe('URNValidator', () => {
-    it('Returns true for valid URN with optional - or /', () => {
-      expect(URNValidator('1111-2222-3333-4444')).to.equal(true);
+    it('Returns true for valid URN with - or / separators between 16 and 22 chars in length', () => {
+      expect(URNValidator('1111-2222-3333-4444')).to.equal(true); // 20 characters
       expect(URNValidator('1111/2222/3333/4444')).to.equal(true);
-      expect(URNValidator('1234567890123456')).to.equal(true);
     });
-
+    
     it('Returns false for invalid URN strings', () => {
       expect(URNValidator('')).to.equal(false);
-      expect(URNValidator('111-2222-3333-4444')).to.equal(false);
-      expect(URNValidator('1111/2222/3333/444')).to.equal(false);
+      expect(URNValidator('1234567890123456')).to.equal(false);
+      expect(URNValidator('111-222-333-444')).to.equal(false);
+      expect(URNValidator('1111-2222-3333')).to.equal(false); // 14 characters
+      expect(URNValidator('1111/2222/3333/444')).to.equal(false); // 19 characters
+      expect(URNValidator('1111/2222/3333/4444/5555')).to.equal(false); // 24 characters
       expect(URNValidator('123456789012345')).to.equal(false);
       expect(URNValidator('123456789012345X')).to.equal(false);
       expect(URNValidator('12345678901234567')).to.equal(false);

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -3,7 +3,7 @@ const { URNValidator } = require('../../apps/evisa/fields/index.js');
 describe('Custom Validators', () => {
   describe('URNValidator', () => {
     it('Returns true for valid URN with - or / separators between 16 and 22 chars in length', () => {
-      expect(URNValidator('1111-2222-3333-4444')).to.equal(true); // 20 characters
+      expect(URNValidator('1111-2222-3333-4444')).to.equal(true); // 19 characters
       expect(URNValidator('1111/2222/3333/4444')).to.equal(true);
     });
     
@@ -12,7 +12,7 @@ describe('Custom Validators', () => {
       expect(URNValidator('1234567890123456')).to.equal(false);
       expect(URNValidator('111-222-333-444')).to.equal(false);
       expect(URNValidator('1111-2222-3333')).to.equal(false); // 14 characters
-      expect(URNValidator('1111/2222/3333/444')).to.equal(false); // 19 characters
+      expect(URNValidator('1111/2222/3333/444')).to.equal(false); // 18 characters
       expect(URNValidator('1111/2222/3333/4444/5555')).to.equal(false); // 24 characters
       expect(URNValidator('123456789012345')).to.equal(false);
       expect(URNValidator('123456789012345X')).to.equal(false);


### PR DESCRIPTION
Validator regex modified to mandate separators between number groups where previously optional.
