### PR TITLE
EVC-22: Add the UAT bucket for evc

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -75,8 +75,10 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                   name: evc-s3-bucket
+                  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+                  name: evc-s3-uat
                   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
                   name: evc-s3-stg
                   {{ else }}
@@ -86,8 +88,10 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                   name: evc-s3-bucket
+                  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+                  name: evc-s3-uat
                   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
                   name: evc-s3-stg
                   {{ else }}
@@ -97,8 +101,10 @@ spec:
             - name: AWS_KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                   name: evc-s3-bucket
+                  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+                  name: evc-s3-uat
                   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
                   name: evc-s3-stg
                   {{ else }}
@@ -108,8 +114,10 @@ spec:
             - name: AWS_BUCKET
               valueFrom:
                 secretKeyRef:
-                  {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
+                  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
                   name: evc-s3-bucket
+                  {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+                  name: evc-s3-uat
                   {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
                   name: evc-s3-stg
                   {{ else }}


### PR DESCRIPTION
## What? 
* Usually we have one s3 bucket for branch and UAT
* Since we started using seperate s3 buckets for each
* We need to make changes to the code

## Why? 
* We are using different s3 buckets for each enivronment for FMR too
* There are two secrets stored in namespace and we delete one of them after the tests

## How? 
* Add if condition to use evs-s3-uat secret


## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


