### PR TITLE
Notify api error handling

### DIFF
--- a/apps/evisa/behaviours/email-caseworker.js
+++ b/apps/evisa/behaviours/email-caseworker.js
@@ -1,11 +1,11 @@
 'use strict';
 /* eslint-disable prefer-const */
-// Send the form data in an Email to the eVisa Agent
+// Send the form data in an Email to the eVisa Caseworker
 
 const Emailer = require('./emailer.js');
 const { SESSION } = require('../constants.js');
 
-module.exports = emailConfig => superclass => class EmailAgent extends superclass {
+module.exports = emailConfig => superclass => class EmailCaseworker extends superclass {
   constructor(...args) {
     super(...args);
     this.emailer = new Emailer(emailConfig);
@@ -13,13 +13,13 @@ module.exports = emailConfig => superclass => class EmailAgent extends superclas
 
   async successHandler(req, res, next) {
     if (req.body['continue-button']) {
-      let personalisation = this.getAgentPersonalisation(req.sessionModel);
-      this.emailer.sendAgentEmail(personalisation);
+      let personalisation = this.getCaseworkerPersonalisation(req.sessionModel);
+      this.emailer.sendCaseworkerEmail(personalisation);
     }
     return super.successHandler(req, res, next);
   }
 
-  getAgentPersonalisation(session) {
+  getCaseworkerPersonalisation(session) {
     const notSupplied = 'not supplied';
     const noneSupplied = 'none supplied';
 

--- a/apps/evisa/behaviours/emailer.js
+++ b/apps/evisa/behaviours/emailer.js
@@ -25,7 +25,7 @@ module.exports = class Emailer {
       this.emailConfig.caseworkerTemplateId,
       this.emailConfig.caseworkerEmail,
       personalisation,
-      EMAIL.TYPE.CASEWORKER
+      EMAIL.RECIPIENT_TYPE.CASEWORKER
     );
   }
 
@@ -34,14 +34,14 @@ module.exports = class Emailer {
       this.emailConfig.customerTemplateId,
       emailAddress,
       personalisation,
-      EMAIL.TYPE.CUSTOMER
+      EMAIL.RECIPIENT_TYPE.CUSTOMER
     );
   }
 
-  async _sendEmail(templateId, emailAddress, personalisation, type) {
+  async _sendEmail(templateId, emailAddress, personalisation, recipientType) {
     try {
       let response = await this.notifyClient.sendEmail(templateId, emailAddress, { personalisation });
-      logger.info(`${type} Email sent successfully: ${response?.data?.id || 'no id'}`);
+      logger.info(`${recipientType} Email sent successfully: ${response?.data?.id || 'no id'}`);
     } catch (err) {
       let errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
       let errorCode = err.code ? `${err.code} -` : '';

--- a/apps/evisa/behaviours/emailer.js
+++ b/apps/evisa/behaviours/emailer.js
@@ -19,7 +19,7 @@ module.exports = class Emailer {
     this.notifyClient = new NotifyClient(emailConfig.notifyApiKey);
   }
 
-  async sendAgentEmail(personalisation) {
+  async sendCaseworkerEmail(personalisation) {
     await this._sendEmail(
       this.emailConfig.caseworkerTemplateId,
       this.emailConfig.caseworkerEmail,

--- a/apps/evisa/behaviours/emailer.js
+++ b/apps/evisa/behaviours/emailer.js
@@ -43,12 +43,10 @@ module.exports = class Emailer {
       let response = await this.notifyClient.sendEmail(templateId, emailAddress, { personalisation });
       logger.info(`${recipientType} Email sent successfully: ${response?.data?.id || 'no id'}`);
     } catch (err) {
-      let errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
-      let errorCode = err.code ? `${err.code} -` : '';
-      let errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
-
+      let errorDetails = JSON.stringify(err.response?.data || '');
+      let errorCode = err.code || '';
+      let errorMessage = `${errorCode} - ${err.message}; Cause: ${errorDetails}`;
       logger.error(`Failed to send Email: ${errorMessage}`);
-      throw Error(errorMessage);
     }
   }
 };

--- a/apps/evisa/behaviours/emailer.js
+++ b/apps/evisa/behaviours/emailer.js
@@ -3,6 +3,7 @@
 
 const NotifyClient = require('notifications-node-client').NotifyClient;
 const logger = require('hof/lib/logger')({ env: process.env });
+const { EMAIL } = require('../constants.js');
 
 module.exports = class Emailer {
   constructor(emailConfig) {
@@ -24,7 +25,7 @@ module.exports = class Emailer {
       this.emailConfig.caseworkerTemplateId,
       this.emailConfig.caseworkerEmail,
       personalisation,
-      'Agent'
+      EMAIL.TYPE.CASEWORKER
     );
   }
 
@@ -33,7 +34,7 @@ module.exports = class Emailer {
       this.emailConfig.customerTemplateId,
       emailAddress,
       personalisation,
-      'Customer'
+      EMAIL.TYPE.CUSTOMER
     );
   }
 

--- a/apps/evisa/constants.js
+++ b/apps/evisa/constants.js
@@ -10,5 +10,11 @@ module.exports = {
     OTHER_REFERENCE_NUMBER: 'other-reference-number',
     QUESTION_FIELD: 'question-field'
   },
-  MAX_FILE_UPLOADS: 5   // Max number of file uploads permitted
+  MAX_FILE_UPLOADS: 5,   // Max number of file uploads permitted
+  EMAIL: {
+    TYPE: {
+      CASEWORKER: 'Caseworker',
+      CUSTOMER: 'Customer'
+    }
+  }
 };

--- a/apps/evisa/constants.js
+++ b/apps/evisa/constants.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   MAX_FILE_UPLOADS: 5,   // Max number of file uploads permitted
   EMAIL: {
-    TYPE: {
+    RECIPIENT_TYPE: {
       CASEWORKER: 'Caseworker',
       CUSTOMER: 'Customer'
     }

--- a/apps/evisa/index.js
+++ b/apps/evisa/index.js
@@ -4,7 +4,7 @@
 const SaveImage = require('./behaviours/save-image');
 const RemoveImage = require('./behaviours/remove-image');
 const config = require('../../config.js');
-const EmailAgent = require('./behaviours/email-caseworker')(config.email);
+const EmailCaseworker = require('./behaviours/email-caseworker')(config.email);
 const EmailCustomer = require('./behaviours/email-customer')(config.email);
 
 module.exports = {
@@ -51,7 +51,7 @@ module.exports = {
       next: '/upload',
     },
     '/upload': {
-      behaviours: [EmailAgent, EmailCustomer, SaveImage('file-selector'), RemoveImage],
+      behaviours: [EmailCaseworker, EmailCustomer, SaveImage('file-selector'), RemoveImage],
       fields: ['file-selector'],
       next: '/confirmation',
     },


### PR DESCRIPTION
When using a "testing" Notify api key the recipient list is limited to registered Team members and a short guest list of email addresses. Attempting to send email to addresses not among those listed results in a error response from Notify. The app's Notify error handling was crashing the app on receipt of a none 200 response. 3rd party failures should not crash the app. Instead the error is logged and the app continues without throwing an unhandled error.

In addition to fixing the crash this PR sees a naming refactor of of Agent => Caseworker as is the convention.


The error logged on Notify api key failure will approximate:
`error: Failed to send Email: ERR_BAD_REQUEST - Request failed with status code 400; Cause: {"errors":[{"error":"BadRequestError","message":"Can’t send to this recipient using a team-only API key"}],"status_code":400} {"timestamp":"2024-09-13T09:52:48.335Z"}`