### PR TITLE
Fix devcontainer file-vault url

### DIFF
--- a/.devcontainer/devcontainer.env.sample
+++ b/.devcontainer/devcontainer.env.sample
@@ -9,9 +9,9 @@ REDIS_INSIGHT_PORT=5540
 # The following environment variables are used to configure [file-vault](https://github.com/UKHomeOffice/file-vault#configuration)
 #
 #  FILE_VAULT_URL            | URL of file-vault, this is used when returning a URL upon successful upload to S3
-FILE_VAULT_URL=http://localhost:3000/file
+FILE_VAULT_URL=http://hof-file-vault:3000/file
 #  CLAMAV_REST_URL           | Location of ClamAV rest service
-CLAMAV_REST_URL=http://localhost:3000/scan
+CLAMAV_REST_URL=http://hof-file-vault:3000/scan
 #  AWS_ACCESS_KEY_ID         | AWS Key ID
 AWS_ACCESS_KEY_ID=
 #  AWS_SECRET_ACCESS_KEY     | AWS Secret Access Key


### PR DESCRIPTION
A recent refresh of the devcontainer's sample .env file overwrote the file-vault urls.