### PR TITLE
EVC-84 Broken Aria reference 

### DIFF
--- a/apps/evisa/translations/src/en/fields.json
+++ b/apps/evisa/translations/src/en/fields.json
@@ -66,6 +66,7 @@
     "hint": "We may call you to ask for more details"
   },
   "question-field": {
-    "label": "Enter your question below. Provide as much detail as possible"
+    "label": "Enter your question below",
+    "hint": "Provide as much detail as possible"
   }
 }


### PR DESCRIPTION
[EVC-84 Broken Aria reference ](https://collaboration.homeoffice.gov.uk/jira/browse/EVC-84)

Splitting Question field label text into label + hint so the HOFF assigned `aria-describedby` has a target.

