### PR TITLE
EVC-102: Update Keycloak proxy ports and configs

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -181,16 +181,6 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
             {{ end }}
-            - name: PROXY_DISCOVERY_URL
-            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://acp-sso.prod.acp.homeoffice.gov.uk/realms/evc
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://acp-sso.prod.acp.homeoffice.gov.uk/realms/evc
-            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/evc-notprod
-            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/evc-notprod
-            {{ end }}
           args:
             # URls that you wish to protect.
             - --resources=uri=/*

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -170,7 +170,7 @@ spec:
             - name: PROXY_LISTEN
               value: 127.0.0.1:3001
             - name: PROXY_UPSTREAM_URL
-              value: "https://127.0.0.1:3000"
+              value: "http://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
@@ -192,31 +192,18 @@ spec:
               value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/evc-notprod
             {{ end }}
           args:
-            - --listen=127.0.0.1:3001
-            # the url which is used to retrieve the OpenID configuration
-            - --discovery-url=$(PROXY_DISCOVERY_URL)
-            # the endpoint where requests are proxied to
-            - --upstream-url=https://127.0.0.1:3000
             # URls that you wish to protect.
             - --resources=uri=/*
-            - --client-id=$(PROXY_CLIENT_ID)
-            - --client-secret=$(PROXY_CLIENT_SECRET)
-            - --tls-cert=/certs/tls.crt
-            - --tls-private-key=/certs/tls.key
             - --enable-default-deny=false
-            - --http-only-cookie=true
             - --enable-security-filter=true
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
-            - --redirection-url=$(PROXY_REDIRECTION_URL)
-            - --tls-min-version=tlsv1.2
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}
           ports:
-            - containerPort: 10080
-            - containerPort: 10443
+            - containerPort: 3001
           securityContext:
             runAsNonRoot: true
           terminationMessagePath: /dev/termination-log
@@ -239,6 +226,9 @@ spec:
               memory: 512Mi
           env:
 {{ file .FILEVAULT_NGINX_SETTINGS | indent 12 }}
+          ports:
+            - containerPort: 10080
+            - containerPort: 10443
           securityContext:
             runAsNonRoot: true
           volumeMounts:

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/kube/file-vault/file-vault-network-policy.yml
+++ b/kube/file-vault/file-vault-network-policy.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/kube/file-vault/file-vault-service.yml
+++ b/kube/file-vault/file-vault-service.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
WHAT?

* This is to protect the uploads with keycloak IAM
* User will have to login with Keycloak credentials to access file
* User will now be able to download a file from the business email
* We are using working example FMR where we have tested fully

WHY?

* Ports used by containers are incorrect.
* We are expecting Nginx to handle the incoming traffic and Keycloak proxy will restrict access to the file

HOW?

* Swap over the ports and remove unnecessary arguments from Keycloak arguments
* Also add missing hyphens at beginning of YAML files 
* Update hof services config and run the build 

TESTING?
* we should see keycloak login page while using filevault url.
* We should be able to download the file
* Link will be sent to email to download the uploaded attachments
