### PR TITLE
EVC-22: Update file vault url in production

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -173,7 +173,7 @@ spec:
               value: "http://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
+              value: https://fv-{{ .APP_NAME }}.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
               value: https://fv-{{ .APP_NAME }}.stg.sas.homeoffice.gov.uk
             {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}


### PR DESCRIPTION
WHAT?
* currently redirecting to an incorrect url which is not allowed in namespace

WHY?
* Fixes the the FV ingress url in production

HOW?
* Update the proxy redirection url

Testing?
* Will test in production