### PR TITLE
EVC-101 Notify Error not passed to Controller

### DIFF
--- a/apps/evisa/behaviours/email-caseworker.js
+++ b/apps/evisa/behaviours/email-caseworker.js
@@ -14,7 +14,11 @@ module.exports = emailConfig => superclass => class EmailCaseworker extends supe
   async successHandler(req, res, next) {
     if (req.body['continue-button']) {
       let personalisation = this.getCaseworkerPersonalisation(req.sessionModel);
-      this.emailer.sendCaseworkerEmail(personalisation);
+      try {
+        await this.emailer.sendCaseworkerEmail(personalisation);
+      } catch (error) {
+        return next(new Error(req.translate('errors.email.caseworker')));
+      }
     }
     return super.successHandler(req, res, next);
   }

--- a/apps/evisa/behaviours/email-customer.js
+++ b/apps/evisa/behaviours/email-customer.js
@@ -15,7 +15,6 @@ module.exports = emailConfig => superclass => class EmailCustomer extends superc
   async successHandler(req, res, next) {
     if (req.body['continue-button']) {
       let emailAddress = req.sessionModel.get(SESSION.EMAIL_FIELD);
-      emailAddress = '';
       if (!emailAddress) {
         let errorMsg = 'Customer email address missing, unable to send confirmation email';
         logger.error(errorMsg);

--- a/apps/evisa/behaviours/email-customer.js
+++ b/apps/evisa/behaviours/email-customer.js
@@ -7,35 +7,35 @@ const { SESSION } = require('../constants.js');
 const logger = require('hof/lib/logger')({ env: process.env });
 
 module.exports = emailConfig => superclass => class EmailCustomer extends superclass {
-    constructor(...args) {
-      super(...args);
-      this.emailer = new Emailer(emailConfig);
-    }
+  constructor(...args) {
+    super(...args);
+    this.emailer = new Emailer(emailConfig);
+  }
 
-    async successHandler(req, res, next) {
-      if (req.body['continue-button']) {
-        let emailAddress = req.sessionModel.get(SESSION.EMAIL_FIELD);
-        emailAddress = '';
-        if (!emailAddress) {
-          let errorMsg = 'Customer email address missing, unable to send confirmation email';
-          logger.error(errorMsg);
-        } else {
-          let personalisation = this.getCustomerPersonalisation(req.sessionModel);
-          try {
-            await this.emailer.sendCustomerEmail(emailAddress, personalisation);
-          } catch (error) {
-            return next(new Error(req.translate('errors.email.confirmation')));
-          }
+  async successHandler(req, res, next) {
+    if (req.body['continue-button']) {
+      let emailAddress = req.sessionModel.get(SESSION.EMAIL_FIELD);
+      emailAddress = '';
+      if (!emailAddress) {
+        let errorMsg = 'Customer email address missing, unable to send confirmation email';
+        logger.error(errorMsg);
+      } else {
+        let personalisation = this.getCustomerPersonalisation(req.sessionModel);
+        try {
+          await this.emailer.sendCustomerEmail(emailAddress, personalisation);
+        } catch (error) {
+          return next(new Error(req.translate('errors.email.confirmation')));
         }
       }
-      return super.successHandler(req, res, next);
     }
+    return super.successHandler(req, res, next);
+  }
 
-    getCustomerPersonalisation(session) {
+  getCustomerPersonalisation(session) {
     const notSupplied = 'not supplied';
-      return {
+    return {
       'customer-name': session.get(SESSION.FULL_NAME) || notSupplied,
       'customer-question': session.get(SESSION.QUESTION_FIELD) || notSupplied
-      };
-    }
-  };
+    };
+  }
+};

--- a/apps/evisa/behaviours/email-customer.js
+++ b/apps/evisa/behaviours/email-customer.js
@@ -7,29 +7,35 @@ const { SESSION } = require('../constants.js');
 const logger = require('hof/lib/logger')({ env: process.env });
 
 module.exports = emailConfig => superclass => class EmailCustomer extends superclass {
-  constructor(...args) {
-    super(...args);
-    this.emailer = new Emailer(emailConfig);
-  }
-
-  async successHandler(req, res, next) {
-    if (req.body['continue-button']) {
-      let emailAddress = req.sessionModel.get(SESSION.EMAIL_FIELD);
-      if (emailAddress) {
-        let personalisation = this.getCustomerPersonalisation(req.sessionModel);
-        this.emailer.sendCustomerEmail(emailAddress, personalisation);
-      } else {
-        logger.error('Customer email address missing, unable to send confirmation email');
-      }
+    constructor(...args) {
+      super(...args);
+      this.emailer = new Emailer(emailConfig);
     }
-    return super.successHandler(req, res, next);
-  }
 
-  getCustomerPersonalisation(session) {
+    async successHandler(req, res, next) {
+      if (req.body['continue-button']) {
+        let emailAddress = req.sessionModel.get(SESSION.EMAIL_FIELD);
+        emailAddress = '';
+        if (!emailAddress) {
+          let errorMsg = 'Customer email address missing, unable to send confirmation email';
+          logger.error(errorMsg);
+        } else {
+          let personalisation = this.getCustomerPersonalisation(req.sessionModel);
+          try {
+            await this.emailer.sendCustomerEmail(emailAddress, personalisation);
+          } catch (error) {
+            return next(new Error(req.translate('errors.email.confirmation')));
+          }
+        }
+      }
+      return super.successHandler(req, res, next);
+    }
+
+    getCustomerPersonalisation(session) {
     const notSupplied = 'not supplied';
-    return {
+      return {
       'customer-name': session.get(SESSION.FULL_NAME) || notSupplied,
       'customer-question': session.get(SESSION.QUESTION_FIELD) || notSupplied
-    };
-  }
-};
+      };
+    }
+  };

--- a/apps/evisa/behaviours/emailer.js
+++ b/apps/evisa/behaviours/emailer.js
@@ -45,8 +45,9 @@ module.exports = class Emailer {
     } catch (err) {
       let errorDetails = JSON.stringify(err.response?.data || '');
       let errorCode = err.code || '';
-      let errorMessage = `${errorCode} - ${err.message}; Cause: ${errorDetails}`;
-      logger.error(`Failed to send Email: ${errorMessage}`);
+      let errorMessage = `Failed to send Email: ${errorCode} - ${err.message}; Cause: ${errorDetails}`;
+      logger.error(errorMessage);
+      throw (err);
     }
   }
 };

--- a/apps/evisa/index.js
+++ b/apps/evisa/index.js
@@ -54,7 +54,7 @@ module.exports = {
       next: '/upload',
     },
     '/upload': {
-      behaviours: [EmailCaseworker, EmailCustomer, SaveImage('file-selector'), RemoveImage],
+      behaviours: [EmailCustomer, EmailCaseworker, SaveImage('file-selector'), RemoveImage],
       fields: ['file-selector'],
       next: '/confirmation',
     },

--- a/apps/evisa/translations/src/en/errors.json
+++ b/apps/evisa/translations/src/en/errors.json
@@ -1,0 +1,6 @@
+{
+    "email": {
+        "caseworker": "There was a problem sending your question email, please try again later.",
+        "confirmation": "There was a problem sending your confirmation email, please try again later."
+      }
+}


### PR DESCRIPTION
[EVC-101 Notify Error not passed to Controller](https://collaboration.homeoffice.gov.uk/jira/browse/EVC-101)

In the case of a failure when sending a Notify email to either caseworker or customer the error will be logged in the container, but the error is not then passed on to the HOF controller, and will register as success on the frontend.

The error is now promoted to the HOF controller which dutifully displays an error message on the frontend and offers a "Try again" button.

![EVC-101-notify-fail-error-msg](https://github.com/user-attachments/assets/5bf14c69-d906-4687-9b44-dda76b6e94bd)
