### PR TITLE
EVC-117 Set Session TTL to 30 minutes

### DIFF
--- a/hof.settings.json
+++ b/hof.settings.json
@@ -10,7 +10,8 @@
     "./apps/evisa"
   ],
   "session": {
-    "name": "evisa.hof.sid"
+    "name": "evisa.hof.sid",
+    "ttl": 1800
   },
   "getAccessibility": false,
   "emailerFallback": true


### PR DESCRIPTION
## What? 
Following on from Bug identified on UAT for the following ticket [EVC-117](https://collaboration.homeoffice.gov.uk/jira/browse/EVC-117) we are now setting the Session TTL directly in the EVC form. 
## Why? 
To comply with WCAG 2.2 accessibility requirements
## How? 
-set ttl value to 1800s in session object in the hof.settings.json file. 
## Testing?
Developer was conducted, to check the session timeout behaviour. 
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
